### PR TITLE
Add mobile menu, animated and responsive

### DIFF
--- a/hooks/useWindowDimensions.ts
+++ b/hooks/useWindowDimensions.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+
+type WindowDimensions = {
+  width: number;
+  height: number;
+};
+
+export const useWindowDimensions = (): WindowDimensions => {
+  const hasWindow = typeof window !== 'undefined';
+
+  const getWindowDimensions = (): WindowDimensions => {
+    const width = hasWindow ? window.innerWidth : 0;
+    const height = hasWindow ? window.innerHeight : 0;
+    return {
+      width,
+      height,
+    };
+  };
+
+  const handleResize = (): void => {
+    setWindowDimensions(getWindowDimensions());
+  };
+
+  const [windowDimensions, setWindowDimensions] = useState<WindowDimensions>(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    if (hasWindow) {
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }
+  }, [hasWindow]);
+
+  return windowDimensions;
+};

--- a/layout/Header/MainMenu/CustomMenuLink.tsx
+++ b/layout/Header/MainMenu/CustomMenuLink.tsx
@@ -10,11 +10,13 @@ export type CustomEntry = {
 type CustomMenuLinkProps = {
   entry: CustomEntry;
   currentRoute: string;
+  isMobile?: boolean;
 };
 
 export const CustomMenuLink = ({
   entry,
   currentRoute,
+  isMobile = false,
 }: CustomMenuLinkProps): ReactElement => {
   const prefixedSlug =
     entry.slug.substring(0, 1) === '/' ? entry.slug : `/${entry.slug}`;
@@ -22,7 +24,7 @@ export const CustomMenuLink = ({
   return (
     <Link key={entry.id} href={prefixedSlug}>
       <a
-        className={`mx-2 text-xl nowrap cursor-pointer ${
+        className={`${!isMobile ? 'mx-2' : ''} text-xl nowrap cursor-pointer ${
           prefixedSlug === currentRoute ? 'underline' : 'hoverUnderline'
         }`}
         aria-label={`Zu ${entry.slug} navigieren`}

--- a/layout/Header/MainMenu/HamburgerMenu/index.tsx
+++ b/layout/Header/MainMenu/HamburgerMenu/index.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement, SetStateAction } from 'react';
+import s from './style.module.scss';
+import cN from 'classnames';
+
+type HamburgerMenuProps = {
+  isActive: boolean;
+  setIsActive: React.Dispatch<SetStateAction<boolean>>;
+};
+
+export const HamburgerMenu = ({
+  isActive,
+  setIsActive,
+}: HamburgerMenuProps): ReactElement => {
+  return (
+    <button
+      className={cN(s.hamburger, { [s.isActive]: isActive })}
+      onClick={() => setIsActive(!isActive)}
+    />
+  );
+};

--- a/layout/Header/MainMenu/HamburgerMenu/style.module.scss
+++ b/layout/Header/MainMenu/HamburgerMenu/style.module.scss
@@ -1,6 +1,7 @@
 .hamburger {
   width: 2.25rem;
   height: 2rem;
+  margin-left: 0.5rem;
   border: none;
   position: relative;
   background: linear-gradient(to bottom, black, black);

--- a/layout/Header/MainMenu/HamburgerMenu/style.module.scss
+++ b/layout/Header/MainMenu/HamburgerMenu/style.module.scss
@@ -1,0 +1,48 @@
+.hamburger {
+  width: 2.25rem;
+  height: 2rem;
+  border: none;
+  position: relative;
+  background: linear-gradient(to bottom, black, black);
+  background-size: 100% 10%;
+  background-repeat: no-repeat;
+  background-position: center center;
+  transition: background-size 0.2s 0.25s ease;
+  cursor: pointer;
+  transition: background-size 0.3s 0.2s ease;
+  outline: none;
+  float: right;
+}
+.hamburger:before,
+.hamburger:after {
+  height: 10%;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  background-color: black;
+  content: '';
+  transition: transform 0.3s ease;
+}
+.hamburger:before {
+  top: 0;
+}
+.hamburger:after {
+  bottom: 0;
+}
+.hamburger:before,
+.hamburger:after {
+  transition: 0.3s ease;
+}
+.hamburger.isActive {
+  background-size: 0 0;
+}
+.hamburger.isActive:before,
+.hamburger.isActive:after {
+  transition-delay: 0.3s;
+}
+.hamburger.isActive:before {
+  transform: translateY(450%) rotate(45deg);
+}
+.hamburger.isActive:after {
+  transform: translateY(-450%) rotate(-45deg);
+}

--- a/layout/Header/MainMenu/MenuLink.tsx
+++ b/layout/Header/MainMenu/MenuLink.tsx
@@ -8,6 +8,7 @@ type MenuLinkProps = {
   currentRoute?: string;
   underlineColor?: UnderlineColor;
   hoverUnderlineColor?: UnderlineColor;
+  isMobile?: boolean;
 };
 
 export const MenuLink = ({
@@ -15,6 +16,7 @@ export const MenuLink = ({
   currentRoute,
   underlineColor = 'BLACK',
   hoverUnderlineColor = 'BLACK',
+  isMobile = false,
 }: MenuLinkProps) => {
   const prefixedSlug =
     entry.slug.substring(0, 1) === '/' ? entry.slug : `/${entry.slug}`;
@@ -22,7 +24,7 @@ export const MenuLink = ({
   return (
     <Link key={entry.id} href={prefixedSlug}>
       <a
-        className={`mx-2 text-xl nowrap ${
+        className={`${isMobile ? 'my-2' : 'mx-2'} text-xl nowrap ${
           prefixedSlug === currentRoute
             ? `underline${underlineColor}`
             : `hoverUnderline${hoverUnderlineColor}`

--- a/layout/Header/MainMenu/UserMenuLink.tsx
+++ b/layout/Header/MainMenu/UserMenuLink.tsx
@@ -81,7 +81,13 @@ export const UserMenuLinkMobile = ({
   const router = useRouter();
 
   if (!isAuthenticated) {
-    return <CustomMenuLink entry={entry} currentRoute={currentRoute} />;
+    return (
+      <CustomMenuLink
+        isMobile={true}
+        entry={entry}
+        currentRoute={currentRoute}
+      />
+    );
   }
 
   return (

--- a/layout/Header/MainMenu/UserMenuLink.tsx
+++ b/layout/Header/MainMenu/UserMenuLink.tsx
@@ -24,7 +24,7 @@ export const UserMenuLink = ({
   }
 
   return (
-    <>
+    <div className="mx-2">
       {customUserData ? (
         <div className={s.dropdown}>
           <div className="items-center">
@@ -64,7 +64,7 @@ export const UserMenuLink = ({
       ) : (
         <span className="text-xl nowrap ml-2">Lade...</span>
       )}
-    </>
+    </div>
   );
 };
 

--- a/layout/Header/MainMenu/UserMenuLink.tsx
+++ b/layout/Header/MainMenu/UserMenuLink.tsx
@@ -67,3 +67,64 @@ export const UserMenuLink = ({
     </>
   );
 };
+
+export const UserMenuLinkMobile = ({
+  entry,
+  currentRoute,
+}: {
+  entry: CustomEntry;
+  currentRoute: string;
+}) => {
+  const { isAuthenticated, customUserData, userId, signUserOut } =
+    useContext(AuthContext);
+  const { togglePageBuilder } = useContext(XbgeAppContext);
+  const router = useRouter();
+
+  if (!isAuthenticated) {
+    return <CustomMenuLink entry={entry} currentRoute={currentRoute} />;
+  }
+
+  return (
+    <>
+      {customUserData ? (
+        <>
+          <div className="items-center my-4">
+            <AvatarImage
+              className={s.loginParentAvatar}
+              user={customUserData}
+              sizes="500"
+            />
+            <span className="text-xl nowrap">{customUserData.username}</span>
+          </div>
+          <div className="mx-2">
+            <div className="my-4">
+              <CustomMenuAction
+                entry={{
+                  action: () => router.push(`/mensch/${userId}`),
+                  label: 'Zum Profil',
+                }}
+              />
+            </div>
+            {customUserData?.directus?.token && (
+              <div className="my-4">
+                <CustomMenuAction
+                  entry={{
+                    action: () => togglePageBuilder(),
+                    label: 'Page Builder',
+                  }}
+                />
+              </div>
+            )}
+            <div className="my-4">
+              <CustomMenuAction
+                entry={{ action: signUserOut, label: 'Abmelden' }}
+              />
+            </div>
+          </div>
+        </>
+      ) : (
+        <span className="text-xl nowrap ml-2">Lade...</span>
+      )}
+    </>
+  );
+};

--- a/layout/Header/MainMenu/index.tsx
+++ b/layout/Header/MainMenu/index.tsx
@@ -50,12 +50,12 @@ export const MainMenu = ({
 };
 
 export const MainMenuMobile = ({
-  mainmenu,
+  mainMenu,
   currentRoute,
 }: MainMenuProps): ReactElement => {
   return (
     <div className="flex-column items-start">
-      {mainmenu.map((entry, index) => {
+      {mainMenu.map((entry, index) => {
         if ((entry as Dropdown).entries)
           return (
             <div key={index}>

--- a/layout/Header/MainMenu/index.tsx
+++ b/layout/Header/MainMenu/index.tsx
@@ -41,12 +41,10 @@ export const MainMenu = ({
           />
         );
       })}
-      <div className="ml-4">
-        <UserMenuLink
-          entry={{ id: 'login', slug: 'login', label: 'Einloggen' }}
-          currentRoute={currentRoute}
-        />
-      </div>
+      <UserMenuLink
+        entry={{ id: 'login', slug: 'login', label: 'Einloggen' }}
+        currentRoute={currentRoute}
+      />
     </div>
   );
 };
@@ -57,10 +55,10 @@ export const MainMenuMobile = ({
 }: MainMenuProps): ReactElement => {
   return (
     <div className="flex-column items-start">
-      {mainmenu.map(entry => {
+      {mainmenu.map((entry, index) => {
         if ((entry as Dropdown).entries)
           return (
-            <>
+            <div key={index}>
               <span className="my-2 text-xl nowrap">{entry.label}</span>
               <div className="mx-4">
                 {(entry as Dropdown).entries.map(entry => {
@@ -75,7 +73,7 @@ export const MainMenuMobile = ({
                   );
                 })}
               </div>
-            </>
+            </div>
           );
         return (
           <MenuLink

--- a/layout/Header/MainMenu/index.tsx
+++ b/layout/Header/MainMenu/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import { Dropdown, Menu, MenuEntry } from '../../../utils/getMenus';
 import { MenuLink } from './MenuLink';
-import { UserMenuLink } from './UserMenuLink';
+import { UserMenuLink, UserMenuLinkMobile } from './UserMenuLink';
 import s from './style.module.scss';
 
 type MainMenuProps = {
@@ -41,7 +41,52 @@ export const MainMenu = ({
           />
         );
       })}
-      <UserMenuLink
+      <div className="ml-4">
+        <UserMenuLink
+          entry={{ id: 'login', slug: 'login', label: 'Einloggen' }}
+          currentRoute={currentRoute}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const MainMenuMobile = ({
+  mainmenu,
+  currentRoute,
+}: MainMenuProps): ReactElement => {
+  return (
+    <div className="flex-column items-start">
+      {mainmenu.map(entry => {
+        if ((entry as Dropdown).entries)
+          return (
+            <>
+              <span className="my-2 text-xl nowrap">{entry.label}</span>
+              <div className="mx-4">
+                {(entry as Dropdown).entries.map(entry => {
+                  return (
+                    <div className="my-4" key={entry.slug}>
+                      <MenuLink
+                        entry={entry}
+                        currentRoute={currentRoute}
+                        isMobile={true}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          );
+        return (
+          <MenuLink
+            entry={entry as MenuEntry}
+            key={(entry as MenuEntry).slug}
+            currentRoute={currentRoute}
+            isMobile={true}
+          />
+        );
+      })}
+      <UserMenuLinkMobile
         entry={{ id: 'login', slug: 'login', label: 'Einloggen' }}
         currentRoute={currentRoute}
       />

--- a/layout/Header/MainMenu/style.module.scss
+++ b/layout/Header/MainMenu/style.module.scss
@@ -27,8 +27,4 @@
   @media (min-width: $breakPointM) {
     min-width: 2rem;
   }
-
-  @media (min-width: $breakPointL) {
-    margin-left: 1.75rem;
-  }
 }

--- a/layout/Header/index.tsx
+++ b/layout/Header/index.tsx
@@ -1,6 +1,9 @@
-import { ReactElement } from 'react';
+import cN from 'classnames';
+import { ReactElement, useState } from 'react';
+import { useWindowDimensions } from '../../hooks/useWindowDimensions';
 import { Menu } from '../../utils/getMenus';
-import { MainMenu } from './MainMenu';
+import { MainMenu, MainMenuMobile } from './MainMenu';
+import { HamburgerMenu } from './MainMenu/HamburgerMenu';
 import { PageLogo } from './PageLogo';
 import s from './style.module.scss';
 
@@ -13,12 +16,30 @@ export const Header = ({
   mainMenu,
   currentRoute,
 }: HeaderProps): ReactElement => {
+  const [mobileMenuActive, setMobileMenuActive] = useState<boolean>(false);
+  const { width } = useWindowDimensions();
+  const isMobile = width < 900;
+
   return (
-    <div className={s.header}>
-      <div className={s.headerContent}>
-        <PageLogo />
-        <MainMenu mainMenu={mainMenu} currentRoute={currentRoute} />
+    <>
+      <div className={s.header}>
+        <div className={s.headerContent}>
+          <PageLogo />
+          {!isMobile ? (
+            <MainMenu mainMenu={mainMenu} currentRoute={currentRoute} />
+          ) : (
+            <HamburgerMenu
+              isActive={mobileMenuActive}
+              setIsActive={setMobileMenuActive}
+            />
+          )}
+        </div>
       </div>
-    </div>
+      {isMobile && mobileMenuActive && (
+        <div className={cN(s.mobileMenu)}>
+          <MainMenuMobile mainMenu={mainMenu} currentRoute={currentRoute} />
+        </div>
+      )}
+    </>
   );
 };

--- a/layout/Header/index.tsx
+++ b/layout/Header/index.tsx
@@ -1,5 +1,5 @@
 import cN from 'classnames';
-import { ReactElement, useState } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { useWindowDimensions } from '../../hooks/useWindowDimensions';
 import { Menu } from '../../utils/getMenus';
 import { MainMenu, MainMenuMobile } from './MainMenu';
@@ -17,8 +17,12 @@ export const Header = ({
   currentRoute,
 }: HeaderProps): ReactElement => {
   const [mobileMenuActive, setMobileMenuActive] = useState<boolean>(false);
+  const [isMobile, setIsMobile] = useState<boolean>(false);
   const { width } = useWindowDimensions();
-  const isMobile = width < 900;
+
+  useEffect(() => {
+    setIsMobile(width < 900);
+  }, [width]);
 
   return (
     <>

--- a/layout/Header/style.module.scss
+++ b/layout/Header/style.module.scss
@@ -10,6 +10,27 @@
 .headerContent {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   max-width: $headerWidth;
   margin: 0 auto;
+}
+
+.mobileMenu {
+  padding: 1rem 2rem;
+  background-color: white;
+  position: fixed;
+  width: 100%;
+  top: $headerHeight;
+  z-index: 45;
+  transform-origin: top;
+  animation: 0.25s ease-in-out 0s 1 expandMenu;
+}
+
+@keyframes expandMenu {
+  0% {
+    transform: scaleY(0);
+  }
+  100% {
+    transform: scaleY(1);
+  }
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -81,13 +81,18 @@ h1 {
 
 h1,
 h2 {
-  @apply text-d-2xl;
+  font-size: 3.375rem;
   letter-spacing: 0.15px;
   margin: 0 0 1rem 0;
   font-weight: bold;
 
-  @media md {
-    @apply text-m-xl;
+  @media (max-width: $breakPointM) {
+    font-size: 2.5rem;
+    hyphens: auto;
+  }
+
+  @media (max-width: $breakPointS) {
+    font-size: 2rem;
     hyphens: auto;
   }
 }


### PR DESCRIPTION
This PR implements a hamburger menu and renderes the main menu for small screens.

For testing the main page is still not ideal, because the sections component is not yet responsive. You can use this page:
https://deploy-preview-11--soft-chaja-98dc01.netlify.app/circles