### PR TITLE
Me page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+.vscode

--- a/components/Forms/DonationForm/index.tsx
+++ b/components/Forms/DonationForm/index.tsx
@@ -680,7 +680,7 @@ const DonationForm = ({ onboardingNextPage }: DonationFormProps) => {
         <FinallyMessage
           className={s.adjustFinallyMessage}
           preventScrolling={true}
-          state="progress"
+          loading
         >
           Sichere Datenübertragung, bitte einen Moment Geduld...
         </FinallyMessage>

--- a/components/Forms/FinallyMessage/index.tsx
+++ b/components/Forms/FinallyMessage/index.tsx
@@ -8,7 +8,7 @@ import { scrollIntoView } from '../../../utils/scrollIntoView';
 type Color = 'white' | 'red' | 'aqua' | 'violet';
 
 type FinallyMessageProps = {
-  state?: string;
+  loading?: boolean;
   children: ReactElement | ReactElement[] | string;
   className?: string;
   preventScrolling?: boolean;
@@ -16,7 +16,7 @@ type FinallyMessageProps = {
 };
 
 export const FinallyMessage = ({
-  state,
+  loading,
   children,
   className,
   preventScrolling,
@@ -47,10 +47,9 @@ export const FinallyMessage = ({
 
   return (
     <div className={className}>
-      {/* {state === 'success' && <HurrayCrowd />} */}
       <div className={cN(s.message, getColorSchmeme(color))} ref={messageRef}>
         <div className={cN(s.messageInner)}>
-          {state === 'progress' && <div className={s.savingIndicator} />}
+          {loading && <div className={s.loadingIndicator} />}
           <div className={s.children}>{children}</div>
         </div>
       </div>

--- a/components/Forms/FinallyMessage/style.module.scss
+++ b/components/Forms/FinallyMessage/style.module.scss
@@ -27,7 +27,7 @@
   width: 100%;
 }
 
-.savingIndicator {
+.loadingIndicator {
   height: 3rem;
   width: 3rem;
   margin-right: 1.5rem;

--- a/components/Forms/Meetup/index.js
+++ b/components/Forms/Meetup/index.js
@@ -98,7 +98,10 @@ export const CreateMeetup = ({
     }
 
     return (
-      <FinallyMessage state={messageState} className={s.message}>
+      <FinallyMessage
+        loading={messageState === 'progress'}
+        className={s.message}
+      >
         {createMeetupState === 'saving' && 'Wird gespeichert...'}
         {createMeetupState === 'saved' && (
           <>

--- a/components/Forms/SelfScan/index.tsx
+++ b/components/Forms/SelfScan/index.tsx
@@ -119,7 +119,7 @@ const CountSignaturesForm = ({
   const needsEMail = !userId && !eMail;
 
   if (state === 'saving') {
-    return <FinallyMessage state="progress">Speichere...</FinallyMessage>;
+    return <FinallyMessage loading>Speichere...</FinallyMessage>;
   }
 
   if (state === 'saved') {
@@ -148,7 +148,7 @@ const CountSignaturesForm = ({
     state === 'listAndUserNotFound'
   ) {
     return (
-      <FinallyMessage state="error">
+      <FinallyMessage>
         <>
           {state === 'userNotFound' && (
             <>

--- a/components/Forms/SignUpFeedbackMessage/index.js
+++ b/components/Forms/SignUpFeedbackMessage/index.js
@@ -30,7 +30,7 @@ const SignUpFeedbackMessage = ({
   }
   return (
     <div className={className}>
-      <FinallyMessage state={finallyState}>
+      <FinallyMessage loading={finallyState === 'progress'}>
         {finallyState === 'progress' && 'Wird abgeschickt...'}
 
         {(state === 'saved' || state === 'success') && (

--- a/components/Forms/SignatureListDownload/index.js
+++ b/components/Forms/SignatureListDownload/index.js
@@ -80,7 +80,7 @@ const SignatureDownloadList = ({ signaturesId }) => {
     signUpState === 'loading'
   ) {
     return (
-      <FinallyMessage state="progress">
+      <FinallyMessage loading>
         Liste wird generiert, bitte einen Moment Geduld...
       </FinallyMessage>
     );
@@ -93,7 +93,7 @@ const SignatureDownloadList = ({ signaturesId }) => {
     });
 
     return (
-      <FinallyMessage state="error">
+      <FinallyMessage>
         Da ist was schief gegangen. Melde dich bitte bei uns{' '}
         <a href="mailto:support@expedition-grundeinkommen.de">
           support@expedition-grundeinkommen.de
@@ -105,7 +105,7 @@ const SignatureDownloadList = ({ signaturesId }) => {
 
   if (state === 'created' && anonymous) {
     return (
-      <FinallyMessage state="success">
+      <FinallyMessage>
         <p>
           Juhu!{' '}
           <a target="_blank" rel="noreferrer" href={pdf.url}>

--- a/components/ListDownload/index.tsx
+++ b/components/ListDownload/index.tsx
@@ -90,7 +90,7 @@ const ListDownload = ({ signaturesId }: ListDownloadProps) => {
     signUpState === 'loading'
   ) {
     return (
-      <FinallyMessage state="progress">
+      <FinallyMessage loading>
         Liste wird generiert, bitte einen Moment Geduld...
       </FinallyMessage>
     );
@@ -98,7 +98,7 @@ const ListDownload = ({ signaturesId }: ListDownloadProps) => {
 
   if (state === 'error') {
     return (
-      <FinallyMessage state="error">
+      <FinallyMessage>
         <>
           Da ist was schief gegangen. Melde dich bitte bei{' '}
           <a href="mailto:support@expedition-grundeinkommen.de">
@@ -112,7 +112,7 @@ const ListDownload = ({ signaturesId }: ListDownloadProps) => {
 
   if (state === 'created' && anonymous) {
     return (
-      <FinallyMessage state="success">
+      <FinallyMessage>
         <p>
           Juhu!{' '}
           <a target="_blank" rel="noreferrer" href={pdf.url}>

--- a/components/Login/EnterLoginCode/index.tsx
+++ b/components/Login/EnterLoginCode/index.tsx
@@ -74,9 +74,7 @@ export const EnterLoginCode = ({
   };
 
   if (answerChallengeState === 'loading' || signInState === 'loading') {
-    return (
-      <FinallyMessage state="progress">Einen Moment bitte...</FinallyMessage>
-    );
+    return <FinallyMessage loading>Einen Moment bitte...</FinallyMessage>;
   }
 
   if (answerChallengeState === 'success') {
@@ -85,7 +83,7 @@ export const EnterLoginCode = ({
 
   if (signInState === 'userNotConfirmed') {
     return (
-      <FinallyMessage state="error">
+      <FinallyMessage>
         <>
           Diese E-Mail-Adresse kennen wir schon, sie wurde aber nie bestätigt -
           Hast du unsere Antwort-Mail bekommen? Dann fehlt nur noch der letzte
@@ -105,7 +103,7 @@ export const EnterLoginCode = ({
 
   if (signInState === 'userNotFound') {
     return (
-      <FinallyMessage state="error">
+      <FinallyMessage>
         <p>
           Oh! Es scheint, diese Email-Addresse ist noch nicht bei uns
           registriert.{' '}
@@ -133,7 +131,7 @@ export const EnterLoginCode = ({
   }
 
   return (
-    <FinallyMessage state="error">
+    <FinallyMessage>
       <>
         {answerChallengeState === 'wrongCode' && (
           <p>

--- a/components/Login/RequestLoginCode/index.tsx
+++ b/components/Login/RequestLoginCode/index.tsx
@@ -35,7 +35,7 @@ export const RequestLoginCode = ({
 
   if (!confirmSendCode) {
     return (
-      <FinallyMessage state="success">
+      <FinallyMessage>
         {children ? (
           children
         ) : (
@@ -90,7 +90,7 @@ export const RequestLoginCodeWithEmail = ({
 
   if (!tempEmail) {
     return (
-      <FinallyMessage state="success">
+      <FinallyMessage>
         <>
           {/* Custom text */}
           {children}

--- a/components/Profile/ProfileWrapper/index.tsx
+++ b/components/Profile/ProfileWrapper/index.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { useState, useContext, useEffect } from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import AuthContext from '../../../context/Authentication';
 import { useSignatureCountOfUser } from '../../../hooks/Api/Signatures/Get';
 import { useBounceToIdentifiedState } from '../../../hooks/Authentication';
@@ -8,11 +7,6 @@ import { LinkButtonLocal } from '../../Forms/Button';
 import { FinallyMessage } from '../../Forms/FinallyMessage';
 import { EnterLoginCode } from '../../Login/EnterLoginCode';
 import { ProfileOverview } from '../ProfileOverview';
-import { PersonalSettings } from '../PersonalSettings';
-// import { ProfileNotifications } from '../ProfileNotifications';
-// import { ProfileSignatures } from '../ProfileSignatures';
-// import { ProfilePledgePackage } from '../ProfilePledgePackage';
-// import { ProfileDonationSettings } from '../ProfileDonationSettings';
 
 type ProfilePageProps = { id: string };
 
@@ -98,53 +92,6 @@ const ProfilePage = ({ id: slugId }: ProfilePageProps) => {
           userId={userId}
           signatureCountOfUser={signatureCountOfUser}
         />
-        // <Router basename={`/mensch/${userId}`}>
-        //   <Routes>
-        //     <Route
-        //       path="/"
-        //       element={
-        //         <ProfileOverview
-        //           userData={userData}
-        //           signatureCountOfUser={signatureCountOfUser}
-        //         />
-        //       }
-        //     />
-
-        //     <Route
-        //       path="/stammdaten"
-        //       element={
-        //         <PersonalSettings
-        //           userData={userData}
-        //           updateCustomUserData={triggerUpdateCustomUserData}
-        //           userId={userId}
-        //         />
-        //       }
-        //     />
-        //     {/* <ProfileSignatures
-        //     userData={userData}
-        //     path="unterschriften-eintragen"
-        //     userId={userId}
-        //   />
-        //   <ProfileNotifications
-        //     userData={userData}
-        //     updateCustomUserData={triggerUpdateCustomUserData}
-        //     path="kontakt-einstellungen"
-        //     userId={userId}
-        //   />
-        //   <ProfilePledgePackage
-        //     userData={userData}
-        //     updateCustomUserData={triggerUpdateCustomUserData}
-        //     path="paket-nehmen"
-        //     userId={userId}
-        //   />
-        //   <ProfileDonationSettings
-        //     userData={userData}
-        //     updateCustomUserData={triggerUpdateCustomUserData}
-        //     path="spenden-einstellungen"
-        //     userId={userId}
-        //   /> */}
-        //   </Routes>
-        // </Router>
       )}
 
       {/* If not authenticated and trying to access different profile show option to go to own user page */}

--- a/components/Section/SectionWrapper.tsx
+++ b/components/Section/SectionWrapper.tsx
@@ -23,6 +23,7 @@ export const SectionWrapper = ({
       }`}
     >
       {status === 'draft' && <h3 className={s.draftLabel}>Entwurf</h3>}
+      {/* TODO: maybe don't nest two sections? */}
       <section className="sections">
         {title && (
           <h2

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,13 +1,53 @@
-import { ReactElement } from 'react';
+import { ReactElement, useContext, useEffect, useState } from 'react';
 import { RequestLoginCodeWithEmail } from '../components/Login/RequestLoginCode';
+import querystring from 'query-string';
+import AuthContext from '../context/Authentication';
+import { useRouter } from 'next/router';
+import { LoadingAnimation } from '../components/LoadingAnimation';
 
 const Login = (): ReactElement => {
+  const { isAuthenticated, setTempEmail } = useContext(AuthContext);
+  const [nextPageParam, setNextPageParam] = useState<string>();
+  const router = useRouter();
+
+  // Remove tempEmail when user navigates away
+  useEffect(() => {
+    return () => {
+      setTempEmail('');
+    };
+  }, []);
+
+  // Get next page from query params
+  useEffect(() => {
+    const params =
+      // Check for window to make sure that build works
+      typeof window !== `undefined`
+        ? // If window, parse params
+          querystring.parse(window.location.search)
+        : undefined;
+
+    if (params?.nextPage && typeof params.nextPage === 'string') {
+      setNextPageParam(params.nextPage);
+    }
+  }, []);
+
+  // If user is authenticated, navigate to home page or the specified next page
+  if (isAuthenticated === true) {
+    router.push(nextPageParam ? `/${nextPageParam}` : '/');
+  }
+
   return (
     <div className="pageWidth colorSchemeWhite">
       <div className="m-16">
-        <RequestLoginCodeWithEmail>
-          <h3>Hey! Schön, dass du da bist. Hier geht&apos;s zum Login.</h3>
-        </RequestLoginCodeWithEmail>
+        {/* This condition is useful, if a user opens the /login page while
+        authenticated, because then the login form would flash before navigating */}
+        {isAuthenticated === false ? (
+          <RequestLoginCodeWithEmail>
+            <h3>Hey! Schön, dass du da bist. Hier geht&apos;s zum Login.</h3>
+          </RequestLoginCodeWithEmail>
+        ) : (
+          <LoadingAnimation />
+        )}
       </div>
     </div>
   );

--- a/pages/me/[[...slug]].tsx
+++ b/pages/me/[[...slug]].tsx
@@ -11,11 +11,18 @@ const MePage = () => {
 
   useEffect(() => {
     // Get path after me/ to redirect to a specifc subpage of profile
-    const splitPath = router.pathname.split('me/');
-    const profilePath =
-      splitPath.length <= 1 ? '' : splitPath[splitPath.length - 1];
+    // See: https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes
+    // The slug in query should usually only be empty or an array, but theoretically
+    // could also be a string
+    let profilePath = '';
 
-    console.log('search', location.search);
+    if (typeof router.query.slug === 'string') {
+      profilePath = router.query.slug;
+    } else if (typeof router.query.slug !== 'undefined') {
+      // Should only have 1 element in the array, but maybe
+      // in the future we will have profile sub pages with more nesting
+      profilePath = router.query.slug.join('/');
+    }
 
     if (userId) {
       router.push(`/mensch/${userId}/${profilePath}${location.search}`);

--- a/pages/me/[[...slug]].tsx
+++ b/pages/me/[[...slug]].tsx
@@ -1,0 +1,35 @@
+import React, { useContext, useEffect } from 'react';
+
+import AuthContext from '../../context/Authentication';
+import { FinallyMessage } from '../../components/Forms/FinallyMessage';
+import { useRouter } from 'next/router';
+import { SectionWrapper } from '../../components/Section/SectionWrapper';
+
+const MePage = () => {
+  const { userId } = useContext(AuthContext);
+  const router = useRouter();
+
+  useEffect(() => {
+    // Get path after me/ to redirect to a specifc subpage of profile
+    const splitPath = router.pathname.split('me/');
+    const profilePath =
+      splitPath.length <= 1 ? '' : splitPath[splitPath.length - 1];
+
+    console.log('search', location.search);
+
+    if (userId) {
+      router.push(`/mensch/${userId}/${profilePath}${location.search}`);
+    } else {
+      router.push(`/login/?nextPage=me%2F${profilePath}${location.search}`);
+    }
+  }, [userId]);
+
+  return (
+    <SectionWrapper colorScheme="colorSchemeWhite">
+      {/* TODO: refactor all the other FinallyMessages */}
+      <FinallyMessage loading>Lade...</FinallyMessage>
+    </SectionWrapper>
+  );
+};
+
+export default MePage;


### PR DESCRIPTION
Transfered /me page, which redirects to login page if not authenticated or redirects to /mensch/{userId}... if authenticated

To test:
test root /me and /me/unterschriften-eintragen or other sub pages of profile page. Test signed in and not signed in.

We also refactored FinallyMessage, because it did not use success and error state anymore. Therefore we just exchanged the state prop with a loading prop. 

Speaking of props, props to Simon, since we did most of it together. 