### PR TITLE
Added jumpmarks

### DIFF
--- a/components/Section/SectionWrapper.tsx
+++ b/components/Section/SectionWrapper.tsx
@@ -1,6 +1,7 @@
 import cN from 'classnames';
 import { ReactElement } from 'react';
 import { ColorScheme, Status } from '.';
+import { stringToId } from '../../utils/stringToId';
 import { DirectusImage } from '../Util/DirectusImage';
 import s from './style.module.scss';
 
@@ -12,6 +13,7 @@ type SectionWrapperProps = {
   hasHero?: boolean;
   heroTitle?: string;
   heroImage?: string;
+  anchor?: string;
 };
 
 export const SectionWrapper = ({
@@ -22,7 +24,10 @@ export const SectionWrapper = ({
   hasHero,
   heroTitle,
   heroImage,
+  anchor,
 }: SectionWrapperProps) => {
+  const anchorId = anchor && stringToId(anchor);
+
   return (
     <>
       {hasHero && heroImage && (
@@ -58,6 +63,12 @@ export const SectionWrapper = ({
           )}
           {children}
         </section>
+
+        {anchorId && (
+          <div id={anchorId} className={s.jumpToAnchor}>
+            <div id={anchorId.toLowerCase()} />
+          </div>
+        )}
       </div>
     </>
   );

--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -32,6 +32,7 @@ export type Section = {
   status: Status;
   layout: Layout;
   colorScheme: ColorScheme;
+  anchor?: string;
   includeAgs: string[];
   excludeAgs: string[];
   hasHero: boolean;
@@ -206,6 +207,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
         hasHero={modifiedSection.hasHero}
         heroImage={modifiedSection.heroImage}
         heroTitle={modifiedSection.heroTitle}
+        anchor={modifiedSection.anchor}
       >
         <>
           <div className="flexWrap">

--- a/components/Section/style.module.scss
+++ b/components/Section/style.module.scss
@@ -180,3 +180,8 @@
   z-index: 2;
   padding: 2rem 1rem;
 }
+
+.jumpToAnchor {
+  position: absolute;
+  top: -$headerHeight;
+}

--- a/layout/index.tsx
+++ b/layout/index.tsx
@@ -10,6 +10,8 @@ import { MunicipalityContext } from '../context/Municipality';
 // This could also be fetched from directus, if frequently edited
 import projects from './projects.json';
 import { getRootAssetURL } from '../components/Util/getRootAssetURL';
+import { useRouter } from 'next/router';
+import { jumpToHash } from '../utils/jumpToHash';
 
 const IS_BERLIN_PROJECT = process.env.NEXT_PUBLIC_PROJECT === 'Berlin';
 
@@ -35,6 +37,7 @@ export const Layout = ({
   mainMenu,
   footerMenu,
 }: LayoutProps): ReactElement => {
+  const router = useRouter();
   const { currentRoute } = useContext(XbgeAppContext);
   const { resetMunicipality } = useContext(MunicipalityContext);
 
@@ -43,6 +46,11 @@ export const Layout = ({
     // municipality page, if not: reset the municipality context.
     if (!currentRoute.includes('orte')) {
       resetMunicipality();
+    }
+
+    const hash = window.location.hash;
+    if (hash) {
+      jumpToHash(hash);
     }
   }, [currentRoute]);
 

--- a/utils/getPageProps.ts
+++ b/utils/getPageProps.ts
@@ -55,6 +55,7 @@ type FetchedSectionData = {
     sort: null | number;
     title: string;
     label: string;
+    anchor?: string;
     layout: Layout;
     colorScheme: ColorScheme;
     includeAgs?: string[];
@@ -72,6 +73,7 @@ const sectionFields = [
   'sort',
   'title',
   'label',
+  'anchor',
   'layout',
   'colorScheme',
   'hasHero',
@@ -216,6 +218,7 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
           status: section.item.status,
           layout: section.item.layout,
           colorScheme: section.item.colorScheme,
+          anchor: section.item.anchor,
           includeAgs: section.item.includeAgs || [],
           excludeAgs: section.item.excludeAgs || [],
           hasHero: section.item.hasHero,

--- a/utils/jumpToHash.ts
+++ b/utils/jumpToHash.ts
@@ -1,0 +1,36 @@
+// We check every x ms if the element of the hash exists and then scroll to it.
+// This is useful for slow internet.
+export const jumpToHash = (hash: string) => {
+  if (hash) {
+    waitForElementToDisplay(
+      hash,
+      (element: Element) => {
+        element.scrollIntoView();
+      },
+      800,
+      15000
+    );
+  }
+};
+
+// Function to wait for the display of an element
+const waitForElementToDisplay = (
+  selector: string,
+  callback: (element: Element) => void,
+  checkFrequencyInMs: number,
+  timeoutInMs: number
+) => {
+  var startTimeInMs = Date.now();
+  (function loopSearch() {
+    const element = document.querySelector(selector);
+    if (element !== null) {
+      callback(element);
+      return;
+    } else {
+      setTimeout(function () {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs) return;
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
+};

--- a/utils/stringToId.ts
+++ b/utils/stringToId.ts
@@ -1,0 +1,4 @@
+// create a valid ID for usage in the DOM
+export function stringToId(string: string) {
+  return string && string.toString().replace(/^[^a-z]+|[^\w:.-]+/gi, '');
+}


### PR DESCRIPTION
I copied the logic from the gatsby project. It's a bit more complex since we had problems with the jumpmark on page load before we fixed it. Therefore I did not think twice and just used the existing logic. Works fine. You can already test it with #ticker on the start page (next.expi). We still need to add anchors to all the sections that need it. 