### PR TITLE
Fixed SelfScan and ChangedEmail

### DIFF
--- a/components/Forms/SelfScan/index.tsx
+++ b/components/Forms/SelfScan/index.tsx
@@ -118,7 +118,7 @@ const CountSignaturesForm = ({
   setListId,
   resetSignatureListState,
 }: CountSignatureFormProps) => {
-  const needsEMail = !userId && !eMail;
+  const needsEmail = !userId && !eMail;
 
   if (state === 'saving') {
     return (
@@ -281,7 +281,7 @@ const CountSignaturesForm = ({
           setCount(parseInt(data.count.toString()));
           updateSignatureList(data);
         }}
-        validate={(values: Values) => validate(values, needsEMail, !listId)}
+        validate={(values: Values) => validate(values, needsEmail, !listId)}
         render={({ handleSubmit }) => {
           return (
             <FinallyMessage>
@@ -290,7 +290,7 @@ const CountSignaturesForm = ({
               </h2>
               <FormWrapper>
                 <form onSubmit={handleSubmit}>
-                  {needsEMail && (
+                  {needsEmail && (
                     <FormSection className={s.formSection}>
                       <Field
                         name="email"
@@ -366,16 +366,18 @@ type Values = {
   userId: string;
 };
 
+type Errors = {
+  count?: string;
+  listId?: string;
+  email?: string;
+};
+
 const validate = (
   values: Values,
-  needsEMail: boolean,
+  needsEmail: boolean,
   needsListId: boolean
 ) => {
-  const errors = {
-    count: '',
-    listId: '',
-    email: '',
-  };
+  const errors: Errors = {};
 
   if (!values.count) {
     errors.count = 'Muss ausgefüllt sein';
@@ -389,7 +391,7 @@ const validate = (
     errors.count = 'Nix, es gibt keine negative Anzahl an Unterschriften!';
   }
 
-  if (needsEMail && !validateEmail(values.email)) {
+  if (needsEmail && !validateEmail(values.email)) {
     errors.email = 'Wir benötigen eine valide E-Mail Adresse';
   }
 

--- a/components/Profile/PersonalSettings/ChangeEmail.tsx
+++ b/components/Profile/PersonalSettings/ChangeEmail.tsx
@@ -165,8 +165,12 @@ export const ChangeEmail = ({
   );
 };
 
+type FormErrors = {
+  email?: string;
+};
+
 const validate = (values: { email: string }, oldEmail: string) => {
-  const errors = { email: '' };
+  const errors: FormErrors = {};
 
   if (values.email && values.email.includes('+')) {
     errors.email = 'Zurzeit unterstützen wir kein + in E-Mails';

--- a/hooks/Api/Signatures/Update/index.tsx
+++ b/hooks/Api/Signatures/Update/index.tsx
@@ -39,6 +39,12 @@ type updateSignatureListByUserProps = {
   count: number;
 };
 
+type Data = {
+  count: number;
+  userId?: string;
+  email?: string;
+};
+
 // function, which makes an api call to set the signature count
 // for a specific list after user has scanned the qr code
 const updateSignatureListByUser = async (
@@ -48,7 +54,7 @@ const updateSignatureListByUser = async (
   // make api call to create new singature list and get pdf
   setState('saving');
 
-  const body = { count, userId: '', email: '' };
+  const body: Data = { count };
 
   // Depending on whether a user id or email was provided
   // we either send only list id or with user id or email


### PR DESCRIPTION
Validation in SelfScan and ChangeEmail did not work, because they were initialized as empty string and Final Form handles empty strings as errors. 

Furthermore SelfScan threw an error, because email and userId were both initialized as empty strings (not the case in the old js code). So both were send to the backend, which does only check for undefined or null. This could be improved in the backend, but also it does not make a whole lot of sense to send empty strings. 