### PR TITLE
Fixed spacing under map

### DIFF
--- a/components/CollectionMap/ShowMeetups.tsx
+++ b/components/CollectionMap/ShowMeetups.tsx
@@ -260,8 +260,8 @@ export const ShowMeetups = ({
                 <div className={s.jumpToAnchor} id="eintragen" />
               </div>
 
-              <section className={cN(s.ctasUnderMap, 'py-16')}>
-                <div>
+              <section className={cN(s.ctasUnderMap)}>
+                <div className={s.cta}>
                   <h3>Plane eine Sammelaktion!</h3>
                   <p>
                     Du hast Lust vor Ort in der Expedition mitzumachen? Hier
@@ -277,7 +277,7 @@ export const ShowMeetups = ({
                     Event erstellen
                   </Button>
                 </div>
-                <div>
+                <div className={s.cta}>
                   <h3>Lege Listen an einem Soli-Ort aus</h3>
                   <p>
                     Markiere einen Ort, an dem du eine neue Unterschriftenliste
@@ -316,7 +316,9 @@ export const ShowMeetups = ({
           )}
 
           {router.asPath === '/' && (
-            <CTALink to="/termine">Weitere Events</CTALink>
+            <CTALink to="/termine" className="mt-8">
+              Weitere Events
+            </CTALink>
           )}
         </div>
       )}

--- a/components/CollectionMap/style.module.scss
+++ b/components/CollectionMap/style.module.scss
@@ -275,4 +275,12 @@
   @media (max-width: $breakPointS) {
     flex-direction: column;
   }
+
+  .cta {
+    margin-top: 4rem;
+
+    @media (max-width: $breakPointS) {
+      margin-top: 2rem;
+    }
+  }
 }


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3089203252

Fixed two issues regarding mobile spacing under map. Ctas to create events now have bigger margins. Also "Weitere Events" has bigger margin. 