### PR TITLE
Cta button links as links

### DIFF
--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -12,7 +12,7 @@ import { SectionWrapper } from './SectionWrapper';
 import { SectionsTextEditable } from './SectionsTextEditable';
 import { YoutubeEmbed } from '../Video/YoutubeEmbed';
 import { XbgeAppContext } from '../../context/App';
-import { CTAButton } from '../Forms/CTAButton';
+import { CTAButton, CTALink, CTALinkExternal } from '../Forms/CTAButton';
 import { useRouter } from 'next/router';
 import { FAQ } from '../FAQ';
 import CollectionMap, { MapConfig } from '../CollectionMap';
@@ -312,25 +312,16 @@ export const Section = ({ section }: SectionProps): ReactElement => {
                               </CTAButton>
                             )}
                             {elementToRender.type === 'href' && (
-                              <CTAButton
-                                onClick={() =>
-                                  window.open(
-                                    elementToRender.href || '',
-                                    '_blank'
-                                  )
-                                }
+                              <CTALinkExternal
+                                href={elementToRender.href || ''}
                               >
                                 {elementToRender.buttonText}
-                              </CTAButton>
+                              </CTALinkExternal>
                             )}
                             {elementToRender.type === 'slug' && (
-                              <CTAButton
-                                onClick={() =>
-                                  router.push(elementToRender.slug || '')
-                                }
-                              >
+                              <CTALink to={elementToRender.slug || ''}>
                                 {elementToRender.buttonText}
-                              </CTAButton>
+                              </CTALink>
                             )}
                           </div>
                         </div>


### PR DESCRIPTION
This pr changes the cta buttons, which are links, to CTALinks instead of CTAButtons. I am not sure if the reasoning behind using buttons was better accessibility for a specific reason. To me, this seems more accessible though, because now it is clear by hovering over an element, that it is a link. Also for screen readers it should be clearer now, since it is using an html link element.

One downside though is, that people who expect the button to be triggered by the spacebar (because it looks like a button) might now be surprised, that some buttons behave that way and others do not. 

We should ask Nico regarding the reasoning. Maybe you got an opinion @schaerta  