### PR TITLE
Align top component via directus

### DIFF
--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -110,6 +110,7 @@ export type SectionElementBase = {
   index: number;
   column: Column;
   groupWithPrevious: boolean;
+  alignTop?: boolean;
 };
 
 export type ColorScheme =
@@ -179,7 +180,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
         <>
           <div className={s.elementContainer}>
             {modifiedSection.render.map((element, index) => {
-              const { column } = element;
+              const { column, alignTop } = element;
 
               if (elementsToSkip.includes(index)) {
                 return null;
@@ -405,6 +406,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
                 <div
                   key={index}
                   className={cN(s.element, {
+                    [s.centerVertically]: !alignTop,
                     [s.elementLeft]: column === 'left',
                     [s.elementRight]: column === 'right',
                     [s.elementLeftThird]: column === 'leftThird',

--- a/components/Section/style.module.scss
+++ b/components/Section/style.module.scss
@@ -161,7 +161,10 @@
 .element {
   margin-bottom: 1rem;
   transition: all 0.25s ease-out;
-  align-self: center;
+
+  &.centerVertically {
+    align-self: center;
+  }
 }
 
 .elementLeft {

--- a/utils/getPageProps.ts
+++ b/utils/getPageProps.ts
@@ -123,6 +123,7 @@ type FetchedElement = {
     state?: string;
     maxBounds?: [Coordinates, Coordinates]; // json
     groupWithPrevious: boolean;
+    alignTop?: boolean;
   };
 };
 
@@ -151,6 +152,7 @@ const elementFields = [
   'maxBounds',
   'props',
   'groupWithPrevious',
+  'alignTop',
 ];
 
 const faqFields = ['title', 'question', 'answer', 'openInitially'];
@@ -248,6 +250,7 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
                 sort: element.item.sort,
                 column: element.item.column || 'centerWide',
                 groupWithPrevious: element.item.groupWithPrevious,
+                alignTop: !!element.item.alignTop,
                 index,
               };
               switch (element.collection) {


### PR DESCRIPTION
Sometimes the vertical centering of components is not ideal, therefore we now have the option to align them top via directus. 