### PR TITLE
Meta directus

### DIFF
--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -110,6 +110,7 @@ export type SectionElementBase = {
   index: number;
   column: Column;
   groupWithPrevious: boolean;
+  alignTop?: boolean;
 };
 
 export type ColorScheme =
@@ -179,7 +180,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
         <>
           <div className={s.elementContainer}>
             {modifiedSection.render.map((element, index) => {
-              const { column } = element;
+              const { column, alignTop } = element;
 
               if (elementsToSkip.includes(index)) {
                 return null;
@@ -405,6 +406,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
                 <div
                   key={index}
                   className={cN(s.element, {
+                    [s.centerVertically]: !alignTop,
                     [s.elementLeft]: column === 'left',
                     [s.elementRight]: column === 'right',
                     [s.elementLeftThird]: column === 'leftThird',

--- a/components/Section/style.module.scss
+++ b/components/Section/style.module.scss
@@ -161,7 +161,10 @@
 .element {
   margin-bottom: 1rem;
   transition: all 0.25s ease-out;
-  align-self: center;
+
+  &.centerVertically {
+    align-self: center;
+  }
 }
 
 .elementLeft {

--- a/layout/index.tsx
+++ b/layout/index.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/router';
 import { jumpToHash } from '../utils/jumpToHash';
 import { LoadingAnimation } from '../components/LoadingAnimation';
 import Script from 'next/script';
+import { getAssetURL } from '../components/Util/getAssetURL';
 
 const IS_BERLIN_PROJECT = process.env.NEXT_PUBLIC_PROJECT === 'Berlin';
 
@@ -32,6 +33,9 @@ type LayoutProps = {
   children: ReactElement;
   mainMenu: Menu;
   footerMenu: Menu;
+  title?: string;
+  description?: string;
+  ogImage?: string;
 };
 
 declare global {
@@ -44,6 +48,9 @@ export const Layout = ({
   children,
   mainMenu,
   footerMenu,
+  title,
+  description,
+  ogImage,
 }: LayoutProps): ReactElement => {
   const router = useRouter();
   const { currentRoute } = useContext(XbgeAppContext);
@@ -89,11 +96,16 @@ export const Layout = ({
     return <>{children}</>;
   }
 
-  const circlesTitle = 'Probier das Grundeinkommen jetzt schon aus';
-  const circlesDescription =
-    'Lass dir ab sofort ein Grundeinkommen ausbezahlen - in der Kryptowährung Circles. Ab dem Zeitpunkt deiner Anmeldung erhältst du jeden Tag 24 neue Circles als Grundeinkommen – das entspricht 72 € im Monat.';
-  const circlesImage =
-    'https://directus.volksentscheid-grundeinkommen.de/assets/d188a364-3e7c-4da2-b69d-98d024021350';
+  const metaDescription =
+    description ||
+    project?.siteDescription ||
+    'Modellversuch zum Grundeinkommen jetzt!';
+  const metaTitle = title || project?.siteTitle || 'Expedition Grundeinkommen';
+  const metaImage = ogImage
+    ? getAssetURL(ogImage)
+    : getRootAssetURL(
+        project?.ogimage || '57331286-2406-4f11-a523-dda6a2166c2e'
+      );
 
   return (
     <>
@@ -103,86 +115,52 @@ export const Layout = ({
         })}
       >
         <Head>
-          {/* TODO: this is kinda hacky, we need to make og stuff editable in directus like
-          before in the gatsby project */}
-          {router.asPath.includes('meine-circles') ? (
-            <>
-              <title>{circlesTitle}</title>
+          <>
+            <title key="title">
+              {`${title ? `${title} - ` : ''}${
+                project?.siteTitle || 'Expedition Grundeinkommen'
+              }`}
+            </title>
+            <meta
+              key="description"
+              name="description"
+              content={metaDescription}
+            />
+            <meta key="og:title" property="og:title" content={metaTitle} />
+            <meta
+              key="og:description"
+              property="og:description"
+              content={metaDescription}
+            />
+            <meta key="og:image" property="og:image" content={metaImage} />
 
-              <meta key="og:image" property="og:image" content={circlesImage} />
-              <meta
-                key="description"
-                name="description"
-                content={circlesDescription}
-              />
-              <meta
-                key="og:description"
-                property="og:description"
-                content={circlesDescription}
-              />
-              <meta key="og:title" property="og:title" content={circlesTitle} />
+            <meta
+              key="twitter:card"
+              name="twitter:card"
+              content="summary_large_image"
+            />
+            <meta
+              key="twitter:site"
+              name="twitter:site"
+              content="@exbeditionbge"
+            />
+            <meta
+              key="twitter:title"
+              name="twitter:title"
+              content={metaTitle}
+            />
+            <meta
+              key="twitter:description"
+              name="twitter:description"
+              content={metaDescription}
+            />
+            <meta
+              key="twitter:image"
+              name="twitter:image"
+              content={metaImage}
+            />
+          </>
 
-              <meta
-                key="twitter:card"
-                name="twitter:card"
-                content="summary_large_image"
-              />
-              <meta
-                key="twitter:site"
-                name="twitter:site"
-                content="@exbeditionbge"
-              />
-              <meta
-                key="twitter:title"
-                name="twitter:title"
-                content={circlesTitle}
-              />
-              <meta
-                key="twitter:description"
-                name="twitter:description"
-                content={circlesDescription}
-              />
-              <meta
-                key="twitter:image"
-                name="twitter:image"
-                content={circlesImage}
-              />
-            </>
-          ) : (
-            <>
-              <title key="title">
-                {project?.siteTitle || 'Expedition Grundeinkommen'}
-              </title>
-              <meta
-                key="description"
-                name="description"
-                content={
-                  project?.siteDescription ||
-                  'Modellversuch zum Grundeinkommen jetzt!'
-                }
-              />
-              <meta
-                key="og:title"
-                property="og:title"
-                content={project?.siteTitle || 'Expedition Grundeinkommen'}
-              />
-              <meta
-                key="og:description"
-                property="og:description"
-                content={
-                  project?.siteDescription ||
-                  'Modellversuch zum Grundeinkommen jetzt!'
-                }
-              />
-              <meta
-                key="og:image"
-                property="og:image"
-                content={getRootAssetURL(
-                  project?.ogimage || '57331286-2406-4f11-a523-dda6a2166c2e'
-                )}
-              />
-            </>
-          )}
           {IS_BERLIN_PROJECT ? (
             <link key="favicon" rel="icon" href="/favicon-berlin.ico" />
           ) : (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,16 +17,15 @@ TrackJS.install({
 });
 
 function XbgeApp({ Component, pageProps, mainMenu, footerMenu }: XbgeAppProps) {
-  console.log('page props', pageProps);
   return (
     <ProviderWrapper>
       <Toaster toastOptions={{ position: 'top-right' }} />
       <Layout
         mainMenu={mainMenu}
         footerMenu={footerMenu}
-        title={pageProps.page.metaTitle}
-        description={pageProps.page.metaDescription}
-        ogImage={pageProps.page.ogImage}
+        title={pageProps.page?.metaTitle}
+        description={pageProps.page?.metaDescription}
+        ogImage={pageProps.page?.ogImage}
       >
         <Component {...pageProps} />
       </Layout>
@@ -40,8 +39,6 @@ function XbgeApp({ Component, pageProps, mainMenu, footerMenu }: XbgeAppProps) {
 XbgeApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext);
   const menus = await getMenus();
-
-  console.log('app props', appProps);
 
   return {
     ...appProps,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,6 +17,7 @@ TrackJS.install({
 });
 
 function XbgeApp({ Component, pageProps, mainMenu, footerMenu }: XbgeAppProps) {
+  console.log('page props', pageProps);
   return (
     <ProviderWrapper>
       <Toaster toastOptions={{ position: 'top-right' }} />
@@ -39,6 +40,8 @@ function XbgeApp({ Component, pageProps, mainMenu, footerMenu }: XbgeAppProps) {
 XbgeApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext);
   const menus = await getMenus();
+
+  console.log('app props', appProps);
 
   return {
     ...appProps,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,13 @@ function XbgeApp({ Component, pageProps, mainMenu, footerMenu }: XbgeAppProps) {
   return (
     <ProviderWrapper>
       <Toaster toastOptions={{ position: 'top-right' }} />
-      <Layout mainMenu={mainMenu} footerMenu={footerMenu}>
+      <Layout
+        mainMenu={mainMenu}
+        footerMenu={footerMenu}
+        title={pageProps.page.metaTitle}
+        description={pageProps.page.metaDescription}
+        ogImage={pageProps.page.ogImage}
+      >
         <Component {...pageProps} />
       </Layout>
       <NoSsr>

--- a/utils/getPageProps.ts
+++ b/utils/getPageProps.ts
@@ -123,6 +123,7 @@ type FetchedElement = {
     state?: string;
     maxBounds?: [Coordinates, Coordinates]; // json
     groupWithPrevious: boolean;
+    alignTop?: boolean;
   };
 };
 
@@ -151,6 +152,7 @@ const elementFields = [
   'maxBounds',
   'props',
   'groupWithPrevious',
+  'alignTop',
 ];
 
 const faqFields = ['title', 'question', 'answer', 'openInitially'];
@@ -248,6 +250,7 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
                 sort: element.item.sort,
                 column: element.item.column || 'centerWide',
                 groupWithPrevious: element.item.groupWithPrevious,
+                alignTop: !!element.item.alignTop,
                 index,
               };
               switch (element.collection) {

--- a/utils/getPageProps.ts
+++ b/utils/getPageProps.ts
@@ -23,6 +23,9 @@ export type Page = {
   heroTitle: string | null;
   heroSubTitle: string | null;
   heroImage: string | null;
+  metaTitle: string | null;
+  metaDescription: string | null;
+  ogImage: string | null;
   sections: Section[];
 };
 
@@ -34,6 +37,9 @@ type FetchedPage = {
   heroTitle: string | null;
   heroSubTitle: string | null;
   heroImage: string | null;
+  metaTitle: string | null;
+  metaDescription: string | null;
+  ogImage: string | null;
   sections: FetchedSectionData[];
 };
 
@@ -45,6 +51,9 @@ const pageFields = [
   'heroTitle',
   'heroSubTitle',
   'heroImage',
+  'metaTitle',
+  'metaDescription',
+  'ogImage',
 ];
 
 type FetchedSectionData = {
@@ -218,6 +227,9 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
     heroTitle: fetchedPage.heroTitle,
     heroSubTitle: fetchedPage.heroSubTitle,
     heroImage: fetchedPage.heroImage,
+    metaTitle: fetchedPage.metaTitle,
+    metaDescription: fetchedPage.metaDescription,
+    ogImage: fetchedPage.ogImage,
     sections: fetchedPage.sections
       .filter(
         s =>


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3156128853

The issue of meta description and og image not being definable via cms anymore was already on my mind a couple of weeks ago. But this now became more apparent because of the meine-circles page. og image and meta tags used to be editable in Contentful. Similarly I now added the fields to directus (on page level).

The fields can be left out. If that is the case the defaults will be used. The titles (which can be seen on the browser tabs) are defined as follows: {title} - Volksentscheid Grundeinkommen Berlin (or Expedition Grundeinkommen). In the old project it used to be Volksentscheind Grundeinkommen - {itle}. But the sooner kind of seems like the standard to me now. But we can change that if you want. 

You can test the new setup on /meine-circles. We will still need to update all pages to set titles and maybe descriptions. And we may need to think about the directus fields title vs metaTitle. Because we never really use title. Let's talk about that in person though.  