### PR TITLE
Enter login code is now white in onboarding

### DIFF
--- a/components/Forms/SignUp/index.tsx
+++ b/components/Forms/SignUp/index.tsx
@@ -130,6 +130,7 @@ type SignUpProps = {
   hideIfAuthenticated?: boolean;
   nudgeBoxText?: string;
   isOnboarding?: boolean;
+  formClassName?: string;
 };
 
 const SignUp = ({
@@ -150,6 +151,7 @@ const SignUp = ({
   hideIfAuthenticated = false,
   nudgeBoxText,
   isOnboarding = false,
+  formClassName,
 }: SignUpProps) => {
   const [signUpState, userExists, signUp, setSignUpState] = useSignUp();
   const [updateUserState, updateUser] = useUpdateUser();
@@ -405,7 +407,7 @@ const SignUp = ({
   };
 
   return (
-    <>
+    <div className={formClassName}>
       {showHeading && (
         <>
           <h3 aria-label="Anmeldeformular">Willkommen bei der Expedition!</h3>
@@ -494,7 +496,7 @@ const SignUp = ({
           );
         }}
       ></Form>
-    </>
+    </div>
   );
 };
 

--- a/components/Forms/SignUp/index.tsx
+++ b/components/Forms/SignUp/index.tsx
@@ -129,6 +129,7 @@ type SignUpProps = {
   optionalNewsletterConsent?: boolean;
   hideIfAuthenticated?: boolean;
   nudgeBoxText?: string;
+  isOnboarding?: boolean;
 };
 
 const SignUp = ({
@@ -148,6 +149,7 @@ const SignUp = ({
   optionalNewsletterConsent = false,
   hideIfAuthenticated = false,
   nudgeBoxText,
+  isOnboarding = false,
 }: SignUpProps) => {
   const [signUpState, userExists, signUp, setSignUpState] = useSignUp();
   const [updateUserState, updateUser] = useUpdateUser();
@@ -239,9 +241,26 @@ const SignUp = ({
                   ? 'colorSchemeRoseOnWhite'
                   : 'colorSchemeWhite'
               }
+              loadingColorScheme={
+                IS_BERLIN_PROJECT ? 'colorSchemeRose' : 'colorSchemeViolet'
+              }
             />
           </div>
         </Modal>
+      );
+    }
+
+    if (isOnboarding) {
+      return (
+        <EnterLoginCode
+          preventSignIn={true}
+          colorScheme={
+            IS_BERLIN_PROJECT ? 'colorSchemeRoseOnWhite' : 'colorSchemeWhite'
+          }
+          loadingColorScheme={
+            IS_BERLIN_PROJECT ? 'colorSchemeRose' : 'colorSchemeViolet'
+          }
+        />
       );
     }
 

--- a/components/Login/EnterLoginCode/index.tsx
+++ b/components/Login/EnterLoginCode/index.tsx
@@ -23,6 +23,7 @@ type EnterLoginCodeProps = {
   buttonText?: string;
   onAnswerChallengeSuccess?: () => void;
   colorScheme?: ColorScheme;
+  loadingColorScheme?: ColorScheme;
   wrongCodeMessage?: ReactElement | string;
   inputClassName?: string;
 };
@@ -33,6 +34,7 @@ export const EnterLoginCode = ({
   buttonText,
   onAnswerChallengeSuccess,
   colorScheme,
+  loadingColorScheme,
   wrongCodeMessage,
   inputClassName,
 }: EnterLoginCodeProps) => {
@@ -82,7 +84,7 @@ export const EnterLoginCode = ({
 
   if (answerChallengeState === 'loading' || signInState === 'loading') {
     return (
-      <FinallyMessage colorScheme={colorScheme} loading>
+      <FinallyMessage colorScheme={loadingColorScheme || colorScheme} loading>
         Einen Moment bitte...
       </FinallyMessage>
     );
@@ -90,7 +92,7 @@ export const EnterLoginCode = ({
 
   if (answerChallengeState === 'success') {
     return (
-      <FinallyMessage colorScheme={colorScheme}>
+      <FinallyMessage colorScheme={loadingColorScheme || colorScheme}>
         Erfolgreich identifiziert.
       </FinallyMessage>
     );

--- a/components/Onboarding/SignUpFlow/index.tsx
+++ b/components/Onboarding/SignUpFlow/index.tsx
@@ -7,7 +7,7 @@ export const SignUpFlow = () => {
   return (
     <PageContainer>
       <div className={s.signupContainer}>
-        <SignUp />
+        <SignUp isOnboarding={true} />
       </div>
     </PageContainer>
   );

--- a/components/Onboarding/SignUpFlow/index.tsx
+++ b/components/Onboarding/SignUpFlow/index.tsx
@@ -6,9 +6,7 @@ import { PageContainer } from '../PageContainer';
 export const SignUpFlow = () => {
   return (
     <PageContainer>
-      <div className={s.signupContainer}>
-        <SignUp isOnboarding={true} />
-      </div>
+      <SignUp isOnboarding={true} formClassName={s.signupContainer} />
     </PageContainer>
   );
 };


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3033753059

The login code form is now on white background. Maybe it should also be full width? 
I also added a new prop loadingColorScheme, because in this scenario we want a different color scheme for the loading and success state than for the form.