### PR TITLE
Don't override delete account button colors

### DIFF
--- a/components/Profile/PersonalSettings/style.module.scss
+++ b/components/Profile/PersonalSettings/style.module.scss
@@ -5,12 +5,6 @@
   @media (max-width: $breakPointM) {
     display: block;
   }
-
-  --button-font-color: #{$white};
-  --button-bg-color: #{$black}; // IE Fallback
-  --button-bg-color: #{$whiteTransparent};
-  --button-hover-bg-color: #{$white};
-  --button-hover-font-color: #{$aqua};
 }
 
 .userInfo {
@@ -75,11 +69,6 @@
 
 .revokeButton {
   margin: 0.5rem;
-  --button-font-color: #{$aqua};
-  --button-bg-color: #{$black}; // IE Fallback
-  --button-bg-color: #{$aquaTransparent};
-  --button-hover-bg-color: #{$aqua};
-  --button-hover-font-color: #{$white};
 }
 
 .revokeButtonRow {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3205685964

Button colors in delete account section are not overriden anymore, but use the existing color scheme. Therefore the colors on the berlin website are not wrong anymore.