### PR TITLE
Add geolocation to jump to current pos on map

### DIFF
--- a/components/CollectionMap/LazyMap.tsx
+++ b/components/CollectionMap/LazyMap.tsx
@@ -138,6 +138,23 @@ const LazyMap = ({
           });
 
           map.current.addControl(geocoder);
+        } else {
+          // For now we want to only either show search or geolocation button. Both take too much space.
+          // It looks weird, and since we still cannot choose a location (when creating an event) on the map
+          // the geolocation is not really helpful in that case
+
+          // Geolocation to jump to current location
+          const geoLocation = new mapboxgl.GeolocateControl({
+            positionOptions: {
+              enableHighAccuracy: true,
+            },
+            // When active the map will receive updates to the device's location as it changes.
+            trackUserLocation: true,
+            // Draw an arrow next to the location dot to indicate which direction the device is heading.
+            showUserHeading: false,
+          });
+
+          map.current.addControl(geoLocation);
         }
       }
 


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3287060531

I added the mapbox geolocation feature to jump to the current position when pressing button on the top right. I did not enable it, when creating a new event or soli location, since it looks weird with the search bar enabled as well. In the future, if we support chosing a location by clicking on the map, then the geolocation would be helpful  in that scenario as well. Until then, it is not really needed.
