### PR TITLE
Fixed visualisation popup overflow made mobile font smaller

### DIFF
--- a/components/CampaignVisualisations/style.module.scss
+++ b/components/CampaignVisualisations/style.module.scss
@@ -27,6 +27,10 @@
   position: relative;
   height: 7.5rem;
   line-height: 1;
+
+  @media (max-width: $breakPointXL) {
+    overflow: hidden;
+  }
 }
 
 .barGoal {
@@ -146,8 +150,8 @@
     font-size: $DesktopFontSizeXL;
   }
 
-  @media (max-width: 360px) {
-    font-size: $DesktopFontSizeXL;
+  @media (max-width: 430px) {
+    font-size: $DesktopFontSizeL;
   }
 
   &::before {
@@ -173,6 +177,10 @@
     z-index: 1;
     bottom: -0.3rem;
     right: 1rem;
+
+    @media (max-width: 430px) {
+      bottom: 0;
+    }
   }
 
   &.outside {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3096965077

Setting overflow:hidden on the bar container leads to the popup being displayed inside the container. Therefore we don't have the issues of the added margin to the right of the bar. 

I also made the font of the current count smaller for small phones, since all of it was not displayed anymore. This only became an issue since we reached 100.000 I think, so good on us I guess :)
