### PR TITLE
Headline of first section as h1

### DIFF
--- a/components/Section/SectionWrapper.tsx
+++ b/components/Section/SectionWrapper.tsx
@@ -15,6 +15,7 @@ type SectionWrapperProps = {
   heroTitle?: string;
   heroImage?: string;
   anchor?: string;
+  isFirstSection?: boolean;
 };
 
 export const SectionWrapper = ({
@@ -26,8 +27,14 @@ export const SectionWrapper = ({
   heroTitle,
   heroImage,
   anchor,
+  isFirstSection = false,
 }: SectionWrapperProps) => {
   const anchorId = anchor && stringToId(anchor);
+
+  const headlineClasses = cN(
+    'mb-4',
+    `${colorScheme === 'colorSchemeWhite' ? 'text-violet' : ''}`
+  );
 
   return (
     <>
@@ -51,16 +58,12 @@ export const SectionWrapper = ({
       >
         {status === 'draft' && <h3 className={s.draftLabel}>Entwurf</h3>}
         <section className="sections">
-          {title && (
-            <h2
-              className={cN(
-                'mb-4',
-                `${colorScheme === 'colorSchemeWhite' ? 'text-violet' : ''}`
-              )}
-            >
-              {title}
-            </h2>
-          )}
+          {title &&
+            (isFirstSection ? (
+              <h1 className={headlineClasses}>{title}</h1>
+            ) : (
+              <h2 className={headlineClasses}>{title}</h2>
+            ))}
           {children}
         </section>
 

--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -124,13 +124,19 @@ export type ColorScheme =
 
 type SectionProps = {
   section: Section;
+  isFirstSection?: boolean;
 };
 
-export const Section = ({ section }: SectionProps): ReactElement => {
+export const Section = ({
+  section,
+  isFirstSection = false,
+}: SectionProps): ReactElement => {
   const { pageBuilderActive } = useContext(XbgeAppContext);
   const [modifiedSection, setModifiedSection] = useState<Section>(section);
   const router = useRouter();
   const [actions] = useActions();
+
+  console.log({ isFirstSection });
 
   // Should be moved to a "EditText" component
   const updateContent = (index: number, content: string): void => {
@@ -177,6 +183,7 @@ export const Section = ({ section }: SectionProps): ReactElement => {
         heroImage={modifiedSection.heroImage}
         heroTitle={modifiedSection.heroTitle}
         anchor={modifiedSection.anchor}
+        isFirstSection={isFirstSection}
       >
         <>
           <div className={s.elementContainer}>

--- a/components/Section/index.tsx
+++ b/components/Section/index.tsx
@@ -136,8 +136,6 @@ export const Section = ({
   const router = useRouter();
   const [actions] = useActions();
 
-  console.log({ isFirstSection });
-
   // Should be moved to a "EditText" component
   const updateContent = (index: number, content: string): void => {
     const origElement = modifiedSection.render[index] as SectionsText;

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -29,8 +29,6 @@ const PageWithSections = ({ page }: PageProps): ReactElement => {
         {page.title && <h2 className="my-8">{page.title}</h2>}
       </div>
       {page.sections.map((section: Section, index: number) => {
-        console.log('index of section', index);
-
         return (
           <Section
             key={section.id}

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -28,8 +28,16 @@ const PageWithSections = ({ page }: PageProps): ReactElement => {
       <div className="pageWidth">
         {page.title && <h2 className="my-8">{page.title}</h2>}
       </div>
-      {page.sections.map((section: Section) => {
-        return <Section key={section.id} section={section} />;
+      {page.sections.map((section: Section, index: number) => {
+        console.log('index of section', index);
+
+        return (
+          <Section
+            key={section.id}
+            section={section}
+            isFirstSection={index === 0}
+          />
+        );
       })}
     </section>
   );

--- a/pages/orte/[slug].tsx
+++ b/pages/orte/[slug].tsx
@@ -53,13 +53,13 @@ const MunicipalityPage = ({ page, municipality }: PageProps): ReactElement => {
           />
         </div>
         <div className={`${s.keyVisualElement} pb-16 pr-16 pl-6 pt-16`}>
-          <h2 className={`z-10 text-violet ${s.keyVisualClaim}`}>
+          <h1 className={`z-10 text-violet ${s.keyVisualClaim}`}>
             {municipality.name ? (
               <b>Hol das Grundeinkommen jetzt nach {municipality.name}</b>
             ) : (
               <b>Hol das Grundeinkommen jetzt in deinen Wohnort!</b>
             )}
-          </h2>
+          </h1>
           <CTALink to="#ticker">Mehr erfahren</CTALink>
         </div>
       </div>


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/3254172011

The first section should display the headline as h1 instead of h2. Except for startpage and municipality page, where I changed the key visual claim to an h1 though. 